### PR TITLE
Add padding to projects application countdown

### DIFF
--- a/src/components/ProjectSection.js
+++ b/src/components/ProjectSection.js
@@ -88,11 +88,11 @@ const ProjectSection = props => {
             >
               {timeLeft.days}
               {' : '}
-              {timeLeft.hours}
+              {timeLeft.hours.toString().padStart(2, '0')}
               {' : '}
-              {timeLeft.minutes}
+              {timeLeft.minutes.toString().padStart(2, '0')}
               {' : '}
-              {timeLeft.seconds}
+              {timeLeft.seconds.toString().padStart(2, '0')}
             </p>
             <div
               style={


### PR DESCRIPTION
Having the project countdown as single-digit numbers in the hour, minute, and second fields made it more difficult to understand that it was representing `days : hours : minutes : seconds`. This change adjusts it so that the hours, minutes, and seconds fields start with a leading `0` if necessary.

Before:
![image](https://user-images.githubusercontent.com/32112321/191387965-73ffb48d-6177-435f-abfc-ea11841c7b7e.png)

After:
![image](https://user-images.githubusercontent.com/32112321/191387687-325dad5e-075d-4f98-80aa-f33c8a5e51bb.png)
